### PR TITLE
run original entrypoint with exec

### DIFF
--- a/start
+++ b/start
@@ -10,7 +10,7 @@ main() {
         echo "[INFO] previous DB found, leave it ..."
     fi
 
-    /docker-entrypoint.sh "$@"
+    exec /docker-entrypoint.sh "$@"
 }
 
 [[ "$0" == "$BASH_SOURCE" ]] && main "$@"


### PR DESCRIPTION
Hi,

The "/start" script don't handle POSIX signals, but original postgres container handle it.
I need to gracefull shutdown when i call docker stop cbreak_cbdb_1.

thx
gabo